### PR TITLE
Small bug fix

### DIFF
--- a/content.js
+++ b/content.js
@@ -103,7 +103,7 @@ try {
           exit_icon.style.top = '21%';
           exit_icon.style.right = '31%';
           expand_icon.style.top = '21%';
-          expand_icon.style.right = '25%';
+          expand_icon.style.right = '34%';
           expand_icon.innerHTML = 'Expand';
           surround_div.style.display = 'none';
         }


### PR DESCRIPTION
The expand button would float off of the screen if the user exited the screen when the popup was enlarged and reclicked the course preview button.